### PR TITLE
Add mvp for build api

### DIFF
--- a/esbuild_bindings.go
+++ b/esbuild_bindings.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"C"
-
 	"github.com/evanw/esbuild/pkg/api"
 )
 
@@ -10,10 +9,29 @@ import (
 func transform(jsx *C.char) *C.char {
 	jsxStr := C.GoString(jsx)
 	result := api.Transform(jsxStr, api.TransformOptions{
-        Loader: api.LoaderJSX,
-    })
+		Loader: api.LoaderJSX,
+	})
 	resultStr := string(result.Code[:])
 	return C.CString(resultStr)
+}
+
+//export build
+func build(input, output *C.char) int {
+	input_str := C.GoString(input)
+	output_str := C.GoString(output)
+
+	result := api.Build(api.BuildOptions{
+		EntryPoints: []string{input_str},
+		Outfile:     output_str,
+		Bundle:      true,
+		Write:       true,
+		LogLevel:    api.LogLevelError,
+	})
+
+	if len(result.Errors) > 0 {
+		return 1
+	}
+	return 0
 }
 
 func main() {}

--- a/esbuild_bindings_wasm.go
+++ b/esbuild_bindings_wasm.go
@@ -6,8 +6,8 @@ import (
 
 func transform(jsxStr string) string {
 	result := api.Transform(jsxStr, api.TransformOptions{
-        Loader: api.LoaderJSX,
-    })
+		Loader: api.LoaderJSX,
+	})
 	resultStr := string(result.Code[:])
 	return resultStr
 }

--- a/src/esbuild_py/__init__.py
+++ b/src/esbuild_py/__init__.py
@@ -1,1 +1,1 @@
-from .esbuild import transform
+from .esbuild import transform, build, EsbuildError

--- a/src/esbuild_py/esbuild.py
+++ b/src/esbuild_py/esbuild.py
@@ -28,11 +28,30 @@ def get_lib_path():
 # - https://github.com/ardanlabs/python-go/blob/db361ab/pyext/checksig.py#L12
 so_filepath = get_lib_path()
 so = ctypes.cdll.LoadLibrary(so_filepath)
+
 transform_binding = so.transform
 transform_binding.argtypes = [ctypes.c_char_p]
 transform_binding.restype = ctypes.c_void_p
+
+build_binding = so.build
+build_binding.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+
+class EsbuildError(Exception):
+    pass
+
+def error_handler(output):
+    if not output == 0:
+        raise EsbuildError("Not valid output")
+
+build_binding.restype = error_handler
+
 free = so.free
 free.argtypes = [ctypes.c_void_p]
+
+def build(input, output):
+    input_str = (input.encode('utf-8'))
+    output_str = (output.encode('utf-8'))
+    build_binding(input_str, output_str)
 
 # Wrap the bound go function.
 def transform(jsx):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,52 @@
+import unittest
+
+import os
+from esbuild_py import build, EsbuildError
+
+class TestTransform(unittest.TestCase):
+    first_file = {
+        "name": './first-file.ts',
+        "content": "export const B: string = 'hello typescript';"
+    }
+    second_file = {
+        "name": './second_file.ts',
+        "content": "import {B} from './first-file'; console.log(B);"
+    }
+    output_file_name = './output.js'
+    expected = '''  
+(() => {
+  // first-file.ts
+  var B = "hello typescript";
+
+  // second_file.ts
+  console.log(B);
+})();
+'''.strip()
+    def write_file(self, file, content = None):
+        file_name= file["name"]
+        try:
+            os.remove(file_name)
+        except OSError:
+            pass
+        with open(file_name, "a") as f:
+            f.write(file["content"] if content is None else content) 
+
+    def atest_error(self):
+        self.write_file(self.first_file)
+        bad_content = "'".join([self.second_file["content"], ""]);
+        self.write_file(self.second_file, bad_content)
+        with self.assertRaises(EsbuildError):
+            build(self.second_file["name"], self.output_file_name)
+
+    def test_build(self):
+        self.write_file(self.first_file)
+        self.write_file(self.second_file)
+        try:
+            build(self.second_file["name"], self.output_file_name)
+            with open(self.output_file_name, "r") as f:
+                result = f.read()
+            os.remove(self.output_file_name)
+        finally:
+            os.remove(self.first_file["name"])
+            os.remove(self.second_file["name"])
+        self.assertEqual(result.strip(), self.expected)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,6 +1,5 @@
 import unittest
-
-from esbuild_py import transform
+from esbuild_py import transform, build
 
 
 class TestTransform(unittest.TestCase):


### PR DESCRIPTION
Maybe you can also expose more from esbuild see #3

My use case. I don't want to install node js, but i still want to use typescript for my frontend application
see https://github.com/phoenixframework/esbuild